### PR TITLE
Some bug fix and field added

### DIFF
--- a/omniflo_lead/omniflo_lead/doctype/stock_action/stock_action.json
+++ b/omniflo_lead/omniflo_lead/doctype/stock_action/stock_action.json
@@ -12,6 +12,7 @@
   "company",
   "posting_date",
   "posting_time",
+  "set_posting_time",
   "from_warehouse",
   "to_warehouse",
   "stock_entry",
@@ -36,6 +37,7 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Posting Date",
+   "read_only_depends_on": "eval:doc.set_posting_time==0",
    "reqd": 1
   },
   {
@@ -45,6 +47,7 @@
    "fieldtype": "Time",
    "in_list_view": 1,
    "label": "Posting Time",
+   "read_only_depends_on": "eval:doc.set_posting_time==0",
    "reqd": 1
   },
   {
@@ -159,12 +162,18 @@
    "label": "Purchase Invoice",
    "options": "Purchase Invoice",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "set_posting_time",
+   "fieldtype": "Check",
+   "label": "Edit Posting Date and Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-16 17:33:46.839890",
+ "modified": "2024-01-08 18:51:56.177364",
  "modified_by": "Administrator",
  "module": "Omniflo Lead",
  "name": "Stock Action",

--- a/omniflo_lead/omniflo_lead/doctype/stock_action/stock_action.py
+++ b/omniflo_lead/omniflo_lead/doctype/stock_action/stock_action.py
@@ -207,7 +207,9 @@ class StockAction(Document):
 	
 	@frappe.whitelist()
 	def set_previous_gle_queue(self):
-		rv=[]
+		if self.reason_type in ["Damage","Expiry"]:
+			return
+		
 		for item in self.items:
 			previous_sle = get_previous_sle(
 						{
@@ -218,8 +220,9 @@ class StockAction(Document):
 						}
 					)
 			previous_stock_queue=previous_sle.get("stock_queue") or []
-			frappe.db.sql(""" update `tabStock Action Item` set previous_stock_queue=%(previous_stock_queue)s where name=%(name)s """,values={"name":item.name,"previous_stock_queue":previous_stock_queue})
-			frappe.db.commit()
+			if previous_stock_queue:
+				frappe.db.sql(""" update `tabStock Action Item` set previous_stock_queue=%(previous_stock_queue)s where name=%(name)s """,values={"name":item.name,"previous_stock_queue":previous_stock_queue})
+				frappe.db.commit()
 
 def set_taxes(doc):
 		taxes=get_taxes_and_charges(master_doctype='Purchase Taxes and Charges Template',master_name=doc.taxes_and_charges)

--- a/omniflo_lead/omniflo_lead/doctype/stock_action/stock_action.py
+++ b/omniflo_lead/omniflo_lead/doctype/stock_action/stock_action.py
@@ -117,6 +117,7 @@ class StockAction(Document):
 	def make_stock_transfer(self):
 		doc=frappe.new_doc("Stock Entry")
 		doc.company=self.company
+		doc.set_posting_time=self.set_posting_time
 		doc.posting_date=self.posting_date
 		doc.posting_time=self.posting_time
 		doc.stock_entry_type="Material Transfer"
@@ -138,6 +139,7 @@ class StockAction(Document):
 		doc=frappe.new_doc("Purchase Invoice")
 		doc.company=self.company
 		doc.supplier=self.supplier
+		doc.set_posting_time=self.set_posting_time
 		doc.posting_date=self.posting_date
 		doc.posting_time=self.posting_time
 		doc.is_return=1

--- a/omniflo_lead/omniflo_lead/doctype/store/store.json
+++ b/omniflo_lead/omniflo_lead/doctype/store/store.json
@@ -17,6 +17,7 @@
   "pincode",
   "phone_no",
   "e_mail",
+  "store_type",
   "latitude",
   "longitude",
   "link",
@@ -84,12 +85,18 @@
    "fieldtype": "Link",
    "label": "Customer Link",
    "options": "Customer"
+  },
+  {
+   "fieldname": "store_type",
+   "fieldtype": "Select",
+   "label": "Store Type",
+   "options": "\nSupermarket\nPharmacy"
   }
  ],
  "icon": "fa fa-user",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-21 20:27:27.840337",
+ "modified": "2024-01-08 18:01:35.782142",
  "modified_by": "Administrator",
  "module": "Omniflo Lead",
  "name": "Store",


### PR DESCRIPTION
1. fix:only set value of previous_stock_queue when reason type is damage or expiry (724b30e)
2. minor feat:store type field and their options are added (979014c)
3. Bug Fix: Backdating Issue in Stock Actions for SE (Stock Entry) and PI (Purchase Invoice)
        A bug exists where backdated entries in stock actions don't reflect in associated Stock Entry (SE) or Purchase Invoice (PI). 
        This occurs due to the set_posting_time field value not being set to 1 for SE or PI, preventing proper backdating.(8433227)
